### PR TITLE
Allow for specifying custom base url in install process

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install ffmpeg-ffprobe-static
 
 *Note:* During installation, it will download the appropriate `ffmpeg`/`ffprobe` binary from the [`b4.3.1` GitHub release](https://github.com/descriptinc/ffmpeg-ffprobe-static/releases/tag/b4.3.1). Use and distribution of the binary releases of FFmpeg are covered by their respective license.
 
-Alternatively, it will fetch binaries from `FFMPEG_FFPROBE_STATIC_BASE_URL` if set as an environment variable.
+Alternatively, it will fetch binaries from `FFMPEG_FFPROBE_STATIC_BASE_URL` if set as an environment variable. The default base URL is https://github.com/descriptinc/ffmpeg-ffprobe-static/releases/download/. The install script will fetch binaries from `BASE_URL/binary-release-tag` (the `binary-release-tag` is set in package.json and can customized by setting `FFMPEG_BINARY_RELEASE`).
 
 
 ### Electron & other cross-platform packaging tools

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ This module is installed via npm:
 $ npm install ffmpeg-ffprobe-static
 ```
 
-*Note:* During installation, it will download the appropriate `ffmpeg` binary from the [`b4.3.1` GitHub release](https://github.com/descriptinc/ffmpeg-ffprobe-static/releases/tag/b4.3.1). Use and distribution of the binary releases of FFmpeg are covered by their respective license.
+*Note:* During installation, it will download the appropriate `ffmpeg`/`ffprobe` binary from the [`b4.3.1` GitHub release](https://github.com/descriptinc/ffmpeg-ffprobe-static/releases/tag/b4.3.1). Use and distribution of the binary releases of FFmpeg are covered by their respective license.
+
+Alternatively, it will fetch binaries from `FFMPEG_FFPROBE_STATIC_BASE_URL` if set as an environment variable.
+
 
 ### Electron & other cross-platform packaging tools
 

--- a/install.js
+++ b/install.js
@@ -142,14 +142,9 @@ const releaseName = (
 )
 const arch = process.env.npm_config_arch || os.arch()
 const platform = process.env.npm_config_platform || os.platform()
-const baseOverride = process.env.FFMPEG_FFPROBE_STATIC_BASE_URL || '';
-if (baseOverride.length > 0) {
-  console.log(`[ffmpeg-ffprobe-static] Using custom base url: ${baseOverride}`);
-}
-const baseUrl = new URL(
-  release,
-  baseOverride || 'https://github.com/descriptinc/ffmpeg-ffprobe-static/releases/download/'
-).href;
+const base = process.env.FFMPEG_FFPROBE_STATIC_BASE_URL || 'https://github.com/descriptinc/ffmpeg-ffprobe-static/releases/download/';
+console.log(`[ffmpeg-ffprobe-static] Using base url: ${base}`);
+const baseUrl = new URL(release, base).href;
 const ffmpegUrl = `${baseUrl}/ffmpeg-${platform}-${arch}`
 const ffprobeUrl = `${baseUrl}/ffprobe-${platform}-${arch}`
 const readmeUrl = `${baseUrl}/${platform}-${arch}.README`

--- a/install.js
+++ b/install.js
@@ -142,7 +142,14 @@ const releaseName = (
 )
 const arch = process.env.npm_config_arch || os.arch()
 const platform = process.env.npm_config_platform || os.platform()
-let baseUrl = `https://github.com/descriptinc/ffmpeg-ffprobe-static/releases/download/${release}`;
+const baseOverride = process.env.FFMPEG_FFPROBE_STATIC_BASE_URL || '';
+if (baseOverride.length > 0) {
+  console.log(`[ffmpeg-ffprobe-static] Using custom base url: ${baseOverride}`);
+}
+const baseUrl = new URL(
+  release,
+  baseOverride || 'https://github.com/descriptinc/ffmpeg-ffprobe-static/releases/download/'
+).href;
 const ffmpegUrl = `${baseUrl}/ffmpeg-${platform}-${arch}`
 const ffprobeUrl = `${baseUrl}/ffprobe-${platform}-${arch}`
 const readmeUrl = `${baseUrl}/${platform}-${arch}.README`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmpeg-ffprobe-static",
-  "version": "4.3.1-rc.2",
+  "version": "4.3.1-rc.3",
   "description": "ffmpeg static binaries for Mac OSX and Linux and Windows",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Allows for setting `FFMPEG_FFPROBE_STATIC_BASE_URL` environment variable, and will fetch the ffmpeg/ffprobe binaries from that location.

Example:

```
FFMPEG_FFPROBE_STATIC_BASE_URL="https://www.google.com" yarn install
yarn install v1.17.3
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
error /Users/srubin/code/test/node_modules/ffmpeg-ffprobe-static: Command failed.
Exit code: 1
Command: node install.js
Arguments:
Directory: /Users/srubin/code/test/node_modules/ffmpeg-ffprobe-static
Output:
[ffmpeg-ffprobe-static] Using custom base url: https://www.google.com
Error: Download failed.
    at /Users/srubin/code/test/node_modules/ffmpeg-ffprobe-static/install.js:94:20
    at /Users/srubin/code/test/node_modules/ffmpeg-ffprobe-static/node_modules/@derhuerst/http-basic/lib/index.js:117:20
    at /Users/srubin/code/test/node_modules/ffmpeg-ffprobe-static/node_modules/@derhuerst/http-basic/lib/index.js:173:24
    at /Users/srubin/code/test/node_modules/ffmpeg-ffprobe-static/node_modules/@derhuerst/http-basic/lib/index.js:272:28
    at /Users/srubin/code/test/node_modules/ffmpeg-ffprobe-static/node_modules/@derhuerst/http-basic/lib/index.js:302:17
    at ClientRequest.<anonymous> (/Users/srubin/code/test/node_modules/ffmpeg-ffprobe-static/node_modules/@derhuerst/http-basic/lib/index.js:337:13)
    at Object.onceWrapper (events.js:422:26)
    at ClientRequest.emit (events.js:315:20)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:641:27)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:126:17) {
  url: 'https://www.google.com/b4.3.1-rc.5/ffmpeg-darwin-x64',
  statusCode: 404
}
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```